### PR TITLE
Remove retired ATX CARS config

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "registrant",
       "version": "1.0.0",
       "dependencies": {
-        "@bsv/sdk": "^1.4.19",
-        "@bsv/wallet-toolbox-client": "^1.2.36",
+        "@bsv/sdk": "^1.8.9",
+        "@bsv/wallet-toolbox-client": "^1.6.35",
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -235,18 +235,17 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.4.19",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.19.tgz",
-      "integrity": "sha512-sFZ6qheYgh2bn8PBKPgnITKJ8K7ZXmZ++CghkOlsP+IL1CTC3ckq1WyJdDq71hUYhqgDN2EfAtIvL+ZFQnYKTg==",
-      "license": "SEE LICENSE IN LICENSE.txt"
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.8.9.tgz",
+      "integrity": "sha512-bB59MXExzcAQapwrbCvwAkADAuRwkb7zWYP9D+9rMbfbwkzI8xVJkpebyNQ+dE2rQlAmChJEUluUgmyYHbX4Mg=="
     },
     "node_modules/@bsv/wallet-toolbox-client": {
-      "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-1.2.36.tgz",
-      "integrity": "sha512-trWnGFSbR4+kElTfN+ooBzKHnYKj4MK4aPZ+o2+d+pIOmcqODf6MBb68Nr+P9ihHg6UXubgQT8ChWCM83LpBnQ==",
-      "license": "SEE LICENSE IN license.md",
+      "version": "1.6.35",
+      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-1.6.35.tgz",
+      "integrity": "sha512-YQvayX1O6dGX3ACrTthGkUqqwnLeKr7XN35szrJgdmP6p56e++ruiDkjKNgmc4OP/fhZaJZby6hxzJvQpk3zRA==",
       "dependencies": {
-        "@bsv/sdk": "^1.4.18"
+        "@bsv/sdk": "^1.8.6",
+        "idb": "^8.0.2"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -3967,6 +3966,11 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4389,7 +4393,6 @@
       "version": "0.1.78",
       "resolved": "https://registry.npmjs.org/metanet-identity-react/-/metanet-identity-react-0.1.78.tgz",
       "integrity": "sha512-JDm9e4nV8+f3mwrUB/0O/DDSSA4cRrceg0hERKN/0a54siL7zu5p9l5TDsrp+ml1eIqbW4LgBIQ+dttckUHMiw==",
-      "license": "Open BSV License",
       "dependencies": {
         "@bsv/sdk": "^1.4.3",
         "@mui/icons-material": "^5.11.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@bsv/sdk": "^1.4.19",
-    "@bsv/wallet-toolbox-client": "^1.2.36",
+    "@bsv/sdk": "^1.8.9",
+    "@bsv/wallet-toolbox-client": "^1.6.35",
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",


### PR DESCRIPTION
Removes the retired cars.atx.systems CARS configuration so the repo only targets the current Babbage CARS deployment.